### PR TITLE
Restructure how moves are stored for Pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ summarized as follows:
 ('ground', 'dragon')
 >>> p.base_stats
 BaseStats(hp=108, attack=130, defense=95, sp_atk=80, sp_def=85, speed=102)
->>> p.moves['swords-dance']['x-y']
-Move(learn_method='machine', level=None)
+>>> [move.name for move in p.moves['sun-moon']] # Garchomp's Sun/Moon move names
+['swords-dance', 'sand-attack', 'sand-attack', 'tackle', ...]
 >>> p.abilities[0] # Is a tuple
 Ability(name='rough-skin', is_hidden=True)
 ```

--- a/pypokedex/pokemon.py
+++ b/pypokedex/pokemon.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from typing import DefaultDict, NamedTuple
+from typing import DefaultDict, List, NamedTuple
 
 from pypokedex.exceptions import PyPokedexError
 
@@ -56,12 +56,11 @@ class Pokemon:
             self.types = tuple(type_['type']['name']
                                for type_ in json_data['types'])
 
-            self.moves = defaultdict(list)
+            self.moves: DefaultDict[str, List[Move]] = defaultdict(list)
 
             for move in json_data['moves']:
                 move_name = move['move']['name']
 
-                games_methods_and_levels = {}
                 for game_details in move['version_group_details']:
                     learn_level = game_details['level_learned_at']
                     learn_method = game_details['move_learn_method']['name']
@@ -70,7 +69,7 @@ class Pokemon:
                         learn_level = None
 
                     self.moves[game_name].append(Move(move_name, learn_method,
-                                                               learn_level))
+                                                      learn_level))
 
         except KeyError as error:
             raise PyPokedexError('A required piece of data was not found for'

--- a/pypokedex/pokemon.py
+++ b/pypokedex/pokemon.py
@@ -1,4 +1,6 @@
-from typing import Dict, NamedTuple
+from collections import defaultdict
+
+from typing import DefaultDict, NamedTuple
 
 from pypokedex.exceptions import PyPokedexError
 
@@ -18,6 +20,7 @@ class BaseStats(NamedTuple):
 
 
 class Move(NamedTuple):
+    name: str
     learn_method: str
     level: int
 
@@ -53,7 +56,7 @@ class Pokemon:
             self.types = tuple(type_['type']['name']
                                for type_ in json_data['types'])
 
-            self.moves: Dict[str, Dict[str, Move]] = {}
+            self.moves = defaultdict(list)
 
             for move in json_data['moves']:
                 move_name = move['move']['name']
@@ -66,10 +69,8 @@ class Pokemon:
                     if learn_level == 0:  # Move not learned by level-up
                         learn_level = None
 
-                    games_methods_and_levels[game_name] = Move(learn_method,
-                                                               learn_level)
-
-                self.moves[move_name] = games_methods_and_levels
+                    self.moves[game_name].append(Move(move_name, learn_method,
+                                                               learn_level))
 
         except KeyError as error:
             raise PyPokedexError('A required piece of data was not found for'

--- a/sample.py
+++ b/sample.py
@@ -1,3 +1,0 @@
-import pypokedex
-
-print(pypokedex.get(name='garchomp').moves['x-y'])

--- a/sample.py
+++ b/sample.py
@@ -1,0 +1,3 @@
+import pypokedex
+
+print(pypokedex.get(name='garchomp').moves['x-y'])

--- a/tests/test_pypokedex.py
+++ b/tests/test_pypokedex.py
@@ -124,8 +124,8 @@ def _is_valid_sample_pokemon(pokemon: pypokedex.pokemon.Pokemon):
             pokemon.base_stats.sp_atk == 4 and
             pokemon.base_stats.sp_def == 5 and
             pokemon.base_stats.speed == 6 and
-            pokemon.moves['move_1']['game_1'] == pypokedex.pokemon.Move('tutor', None) and  # noqa
-            pokemon.moves['move_1']['game_2'] == pypokedex.pokemon.Move('level-up', 5))  # noqa
+            pokemon.moves['game_1'][0] == pypokedex.pokemon.Move('move_1', 'tutor', None) and  # noqa
+            pokemon.moves['game_2'][0] == pypokedex.pokemon.Move('move_1', 'level-up', 5))  # noqa
 
 
 def setup_function():


### PR DESCRIPTION
Currently, pokemon moves can be found by checking if a key exists in `pokemon.moves`. In order to see if this is valid for a specific game, one needs to check if its name is a valid key for the specific move. 

This should be changed so that moves are accessed through individual games instead.

i.e:

```python
m = pokemon.moves['move-name']['game-name']
```

to:

 ```python
for move in pokemon.moves['game-name']:
    move_name = move.name
    ...
```
