### PR TITLE
Expand public api of package and declare all members

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ pokemon = pypokedex.get(dex=DEX)  # DEX must be a valid _national_ pokedex
 pokemon2 = pypokedex.get(name=NAME)  # NAME must be a valid name of a pokemon
 ```
 
+In addition to the above function, the following classes are provided as part of the public API:
+ 
+ - `Pokemon` (returned by `get`),
+ - `BaseStats`,
+ - `Ability`,
+ - `Sprites`,
+ - and `Move`
+ 
+Note that they shouldn't be initialized through client code; their purpose is mainly for type annotations.
+
 ### Possible Exceptions
 
 - A `TypeError` will be raised if the wrong number of arguments or the wrong

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In addition to the above function, the following classes are provided as part of
  - `Sprites`,
  - and `Move`
  
-Note that they shouldn't be initialized through client code; their purpose is mainly for type annotations.
+Note that these classes shouldn't be initialized through client code; their purpose is mainly for type annotations.
 
 ### Possible Exceptions
 

--- a/pypokedex/__init__.py
+++ b/pypokedex/__init__.py
@@ -1,3 +1,5 @@
 from pypokedex.api import get
+from pypokedex.pokemon import Pokemon, BaseStats, Ability, Sprites, Move
 
 __version__ = "1.3.1"
+__all__ = ["get", "Pokemon", "BaseStats", "Ability", "Sprites", "Move"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,13 +7,14 @@ python-tag = py36
 [flake8]
 exclude = .git, __pycache__, build, dist
 
+[mypy]
+namespace_packages = True
+
 [mypy-pytest.*]
 ignore_missing_imports = True
 
 [mypy-responses.*]
 ignore_missing_imports = True
-
-
 
 [tool:pytest]
 addopts = -v

--- a/tests/test_pypokedex.py
+++ b/tests/test_pypokedex.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 import pypokedex
-from pypokedex.pokemon import Ability, BaseStats, Move, Pokemon, Sprites
+from pypokedex import Ability, BaseStats, Move, Pokemon, Sprites
 from pypokedex.exceptions import PyPokedexError, PyPokedexHTTPError
 
 from tests.sample_pokemon import SAMPLE_POKEMON


### PR DESCRIPTION
PEP8 recommends setting the `__all__`  variable for public apis. This shouldn't break the existing API because the old way of accessing the Pokemon related classes is still possible.

TODO:
- [x] Include Pokemon related classes in public api.
- [x] Declare `__all__` variable.
- [x] Update tests.
- [x] Update docs.